### PR TITLE
Line 183 (BlockFloatCompander::BlockFloatExpand_Basic) Func.

### DIFF
--- a/fhi_lib/lib/src/xran_compression.cpp
+++ b/fhi_lib/lib/src/xran_compression.cpp
@@ -179,6 +179,7 @@ BlockFloatCompander::BlockFloatExpand_Basic(const CompressedData& dataIn, Expand
       auto dataIdxIn = (expIdx + 1) + re;
       auto thisData = (int16_t)dataIn.dataCompressed[dataIdxIn];
       auto thisExp = (int16_t)dataIn.dataCompressed[expIdx];
+      
       dataOut->dataExpanded[dataIdxOut] = (int16_t)(thisData << thisExp);
     }
   }


### PR DESCRIPTION
Consider iqwidth = 8, thisExp = 3. In this case how can just left shifting can perform Decompression?
I mean if 
thisData = SXXX XXXX;
dataExpanded  =  thisData<<3;
                          = 0000 0000 SXXX XXXX;
But we need , 
dataExpanded = S000 0000 0XXX XXXX;